### PR TITLE
Fix plotly install command

### DIFF
--- a/content/pyolite/plotly.ipynb
+++ b/content/pyolite/plotly.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import micropip\n",
     "\n",
-    "micropip.install('plotly');"
+    "await micropip.install('plotly')"
    ]
   },
   {


### PR DESCRIPTION
To `await` the install and avoid issue when queuing cells for execution.