### PR TITLE
Fixed issue with missing canvas.size property

### DIFF
--- a/content/pyolite/ipycanvas.ipynb
+++ b/content/pyolite/ipycanvas.ipynb
@@ -62,7 +62,7 @@
     },
     {
       "cell_type": "code",
-      "source": "def draw(x, canvas, color='black'):\n    with hold_canvas(canvas):\n        canvas.clear()\n        canvas.fill_style = '#FFF0C9'\n        canvas.rough_fill_style = 'solid'\n        canvas.fill_rect(-10, -10, canvas.size[0] + 10, canvas.size[1] + 10)\n        canvas.rough_fill_style = 'cross-hatch'\n\n        canvas.fill_style = color\n        canvas.stroke_style = color\n\n        living_cells = np.where(x)\n        \n        rects_x = living_cells[1] * n_pixels\n        rects_y = living_cells[0] * n_pixels\n\n        canvas.fill_rects(rects_x, rects_y, n_pixels)\n        canvas.stroke_rects(rects_x, rects_y, n_pixels)",
+      "source": "def draw(x, canvas, color='black'):\n    with hold_canvas(canvas):\n        canvas.clear()\n        canvas.fill_style = '#FFF0C9'\n        canvas.rough_fill_style = 'solid'\n        canvas.fill_rect(-10, -10, canvas.width + 10, canvas.height + 10)\n        canvas.rough_fill_style = 'cross-hatch'\n\n        canvas.fill_style = color\n        canvas.stroke_style = color\n\n        living_cells = np.where(x)\n        \n        rects_x = living_cells[1] * n_pixels\n        rects_y = living_cells[0] * n_pixels\n\n        canvas.fill_rects(rects_x, rects_y, n_pixels)\n        canvas.stroke_rects(rects_x, rects_y, n_pixels)",
       "metadata": {
         "trusted": true
       },
@@ -80,7 +80,7 @@
     },
     {
       "cell_type": "code",
-      "source": "n_pixels = 15\n\ncanvas = RoughCanvas(width=x.shape[1]*n_pixels, height=x.shape[0]*n_pixels)\ncanvas.fill_style = '#FFF0C9'\ncanvas.rough_fill_style = 'solid'\ncanvas.fill_rect(0, 0, canvas.size[0], canvas.size[1])\n\ncanvas",
+      "source": "n_pixels = 15\n\ncanvas = RoughCanvas(width=x.shape[1]*n_pixels, height=x.shape[0]*n_pixels)\ncanvas.fill_style = '#FFF0C9'\ncanvas.rough_fill_style = 'solid'\ncanvas.fill_rect(0, 0, canvas.width, canvas.height)\n\ncanvas",
       "metadata": {
         "trusted": true
       },


### PR DESCRIPTION
The original code references a missing size property of RoughCanvas. Instead use the width and height properties