### PR TITLE
Revert "Update to `jupyterlite==0.1.0b9`"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ipyevents>=2.0.1
 ipyleaflet
 ipympl>=0.8.2
 ipywidgets>=7.7,<8
-jupyterlab~=3.4.3
+jupyterlab~=3.3.0
 jupyterlab-drawio
 jupyterlab-language-pack-fr-FR
 jupyterlab-language-pack-zh-CN
@@ -12,7 +12,7 @@ jupyterlab-fasta>=3,<4
 jupyterlab-geojson>=3,<4
 jupyterlab-tour
 jupyterlab_miami_nights
-jupyterlite==0.1.0b9
+jupyterlite==0.1.0b8
 jupyterlite-p5-kernel==0.1.0a12
 jupyterlite-xeus-lua==0.3.1
 jupyterlite-xeus-wren==0.2.1


### PR DESCRIPTION
Temporarily reverts jupyterlite/demo#86 to investigate issue when embedding a REPL with an IFrame.