### PR TITLE
Reorganize and annotate requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,41 @@
-bqplot
-ipycanvas>=0.9.1
-ipyevents>=2.0.1
-ipyleaflet
-ipympl>=0.8.2
-ipywidgets>=8.0.0,<9
-jupyterlab~=3.5.1
-jupyterlab-language-pack-fr-FR
-jupyterlab-language-pack-zh-CN
-jupyterlab-fasta>=3,<4
-jupyterlab-geojson>=3,<4
-jupyterlab-tour
-jupyterlab_miami_nights
+# Core modules (mandatory)
 jupyterlite-core==0.1.0b19
 jupyterlite-pyodide-kernel==0.0.5
-jupyterlite-p5-kernel==0.1.0
-jupyterlite-xeus-lua==0.3.1
+jupyterlab~=3.5.1
+
+# Language support (optional)
+jupyterlab-language-pack-fr-FR
+jupyterlab-language-pack-zh-CN
+
+# SQLite kernel (optional)
 jupyterlite-xeus-sqlite==0.2.1
-plotly>=5,<6
+# P5 kernel (optional)
+jupyterlite-p5-kernel==0.1.0
+# Lua kernel (optional)
+jupyterlite-xeus-lua==0.3.1
+
+# JupyterLab: Fasta file renderer (optional)
+jupyterlab-fasta>=3,<4
+# JupyterLab: Geojson file renderer (optional)
+jupyterlab-geojson>=3,<4
+# JupyterLab: guided tour (optional)
+jupyterlab-tour
+# JupyterLab: dark theme
 jupyterlab-night
+# JupyterLab: Miami nights theme (optional)
+jupyterlab_miami_nights
+
+# Python: ipywidget library for Jupyter notebooks (optional)
+ipywidgets>=8.0.0,<9
+# Python: ipyevents library for Jupyter notebooks (optional)
+ipyevents>=2.0.1
+# Python: interative Matplotlib library for Jupyter notebooks (optional)
+ipympl>=0.8.2
+# Python: ipycanvas library for Jupyter notebooks (optional)
+ipycanvas>=0.9.1
+# Python: ipyleaflet library for Jupyter notebooks (optional)
+ipyleaflet
+
+# Python: plotting libraries (optional)
+plotly>=5,<6
+bqplot


### PR DESCRIPTION
After [a discussion](https://github.com/jupyterlite/jupyterlite/issues/1017) with @jtpio, this PR aims at reorganizing and annotating dependencies in `requirements.txt`.

Users should be able to customize more easily their deployments of JupyterLite.