### PR TITLE
Add manual build and deploy to help learning experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ This section does the same as the Github Action based automatic build & deploy d
   jupyter lite build --contents content --output-dir dist
   ```
 
+- Serve static site in `./dist` locally:
+
+  ```sh
+  python -m http.server -d dist 3000
+  ```
+
+  Visit http://localhost:3000
+
 - git commit and push to your repo:
 
   ```sh
@@ -65,14 +73,6 @@ This section does the same as the Github Action based automatic build & deploy d
   git push -u origin main
   ```
 
-- Serve static site in `./dist` locally:
-
-  ```sh
-  python -m http.server -d dist 3000
-  ```
-
-  Visit http://localhost:3000
-
 - Deploy static site in `./dist` to GitHub Pages:
 
   ```sh
@@ -80,7 +80,7 @@ This section does the same as the Github Action based automatic build & deploy d
   . ./deploy-ghp.sh
 
   # win
-  deploy-ghp.batch
+  deploy-ghp.bath
   ```
 
   Visit [gh-pages](https://docs.github.com/en/pages) static site: `https://[YOURNAME].github.io/[YOURREPO]`.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ jupyter lite build --contents content --output-dir dist
 - git commit and push to your repo:
 
 ```sh
+git init
 git add . && git commit -m "Init"
 git remote add origin https://github.com/[YOURNAME]/jupyterlite-demo.git
 git branch -M main
@@ -74,7 +75,7 @@ git push -u origin main
 deploy-ghp.batch
 ```
 
-- Visit gh-pages static site: https://github.
+- Visit gh-pages static site: `https://[YOURNAME].github.io/[YOURREPO]`.
 
 ## Further Information and Updates
 

--- a/README.md
+++ b/README.md
@@ -27,55 +27,63 @@ This section does the same as the Github Action based automatic build & deploy d
 
 - git clone the repo:
 
-```sh
-mkdir work-zone # a working dir
-cd work-zone
+  ```sh
+  mkdir work-zone # a working dir
+  cd work-zone
 
-git clone https://github.com/jupyterlite/demo.git
-cd demo
-rm -rf .git
-```
+  git clone https://github.com/jupyterlite/demo.git
+  cd demo
+  rm -rf .git
+  ```
 
 - Create a dedicated conda/mamba env:
 
-```sh
-conda create -n lite-demo python=3.10 -y
-conda activate lite-demo
-pip install -r requirements.txt
-```
+  ```sh
+  conda create -n lite-demo python=3.10 -y
+  conda activate lite-demo
+  pip install -r requirements.txt
+  ```
 
 - Build jupyterlite static site:
 
-```sh
-# rm to start from clean sheet
-rm ./.jupyterlite.doit.db
-rm -rf ./dist
-rm -rf ./lite/.cache
+  ```sh
+  # rm to start from clean sheet
+  rm ./.jupyterlite.doit.db
+  rm -rf ./dist
+  rm -rf ./lite/.cache
 
-jupyter lite build --contents content --output-dir dist
-```
+  jupyter lite build --contents content --output-dir dist
+  ```
 
 - git commit and push to your repo:
 
-```sh
-git init
-git add . && git commit -m "Init"
-git remote add origin https://github.com/[YOURNAME]/jupyterlite-demo.git
-git branch -M main
-git push -u origin main
-```
+  ```sh
+  git init
+  git add . && git commit -m "Init"
+  git remote add origin https://github.com/[YOURNAME]/jupyterlite-demo.git
+  git branch -M main
+  git push -u origin main
+  ```
+
+- Serve static site in `./dist` locally:
+
+  ```sh
+  python -m http.server -d dist 3000
+  ```
+
+  Visit http://localhost:3000
 
 - Deploy static site in `./dist` to GitHub Pages:
 
-```sh
-# linux
-. ./deploy-ghp.sh
+  ```sh
+  # linux
+  . ./deploy-ghp.sh
 
-# win
-deploy-ghp.batch
-```
+  # win
+  deploy-ghp.batch
+  ```
 
-- Visit gh-pages static site: `https://[YOURNAME].github.io/[YOURREPO]`.
+  Visit [gh-pages](https://docs.github.com/en/pages) static site: `https://[YOURNAME].github.io/[YOURREPO]`.
 
 ## Further Information and Updates
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,61 @@ JupyterLite is being tested against modern web browsers:
 
 Check out the guide on the JupyterLite documentation: https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html
 
+## Manual build and deploy to GitHub Pages
+
+This section does the same as the Github Action based automatic build & deploy described in the previous one, but offers a step by step approach which possibly offers a better learning experience.
+
+- git clone the repo:
+
+```sh
+mkdir work-zone # a working dir
+cd work-zone
+
+git clone https://github.com/jupyterlite/demo.git
+cd demo
+rm -rf .git
+```
+
+- Create a dedicated conda/mamba env:
+
+```sh
+conda create -n lite-demo python=3.10 -y
+conda activate lite-demo
+pip install -r requirements.txt
+```
+
+- Build jupyterlite static site:
+
+```sh
+# rm to start from clean sheet
+rm ./.jupyterlite.doit.db
+rm -rf ./dist
+rm -rf ./lite/.cache
+
+jupyter lite build --contents content --output-dir dist
+```
+
+- git commit and push to your repo:
+
+```sh
+git add . && git commit -m "Init"
+git remote add origin https://github.com/[YOURNAME]/jupyterlite-demo.git
+git branch -M main
+git push -u origin main
+```
+
+- Deploy static site in `./dist` to GitHub Pages:
+
+```sh
+# linux
+. ./deploy-ghp.sh
+
+# win
+deploy-ghp.batch
+```
+
+- Visit gh-pages static site: https://github.
+
 ## Further Information and Updates
 
 For more info, keep an eye on the JupyterLite documentation:

--- a/deploy-ghp.bat
+++ b/deploy-ghp.bat
@@ -1,0 +1,40 @@
+REM make sure git is clear:
+REM git status --porcelain
+
+git push origin --delete gh-pages
+git branch -D gh-pages
+
+git checkout --orphan gh-pages
+
+git rm --cached -rf . 
+
+git add deploy-ghp.bat
+git commit -m "Add deploy script"
+
+REM git clean -n
+git clean -f
+
+git rm --cached deploy-ghp.bat
+git commit -m "Remove deploy script"
+
+REM delete folders/files
+rd /s /q ph_tools
+del README.md requirements.txt pyproject.toml setup.py
+
+REM only files/dir from .\doc will be commited
+xcopy /s doc .
+copy index.html 404.html
+
+echo doc > .gitignore
+echo build >> .gitignore
+echo dist >> .gitignore
+echo wip >> .gitignore
+echo utils >> .gitignore
+echo scripts-* >> .gitignore
+echo *.egg-info >> .gitignore
+
+git add .
+git commit -m "Deploy"
+git push --set-upstream origin gh-pages
+
+git checkout main

--- a/deploy-ghp.bat
+++ b/deploy-ghp.bat
@@ -6,32 +6,22 @@ git branch -D gh-pages
 
 git checkout --orphan gh-pages
 
-git rm --cached -rf . 
+git rm --cached -rf .
 
-git add deploy-ghp.bat
+git add deploy-ghp.sh
 git commit -m "Add deploy script"
 
-REM git clean -n
+# git clean -n
 git clean -f
 
-git rm --cached deploy-ghp.bat
+git rm --cached deploy-ghp.sh
 git commit -m "Remove deploy script"
 
-REM delete folders/files
-rd /s /q ph_tools
-del README.md requirements.txt pyproject.toml setup.py
+REM remove all but deploy script
+rm -rf .github content repl .gitignore .jupyterlite.doit.db deploy-ghp.bat README.md requirements.txt
 
-REM only files/dir from .\doc will be commited
-xcopy /s doc .
-copy index.html 404.html
-
-echo doc > .gitignore
-echo build >> .gitignore
-echo dist >> .gitignore
-echo wip >> .gitignore
-echo utils >> .gitignore
-echo scripts-* >> .gitignore
-echo *.egg-info >> .gitignore
+REM only files/dir from ./dist will be commited
+cp -r ./dist/* ./
 
 git add .
 git commit -m "Deploy"

--- a/deploy-ghp.bat
+++ b/deploy-ghp.bat
@@ -18,7 +18,7 @@ git rm --cached deploy-ghp.sh
 git commit -m "Remove deploy script"
 
 REM remove all but deploy script
-rm -rf .github content repl .gitignore .jupyterlite.doit.db deploy-ghp.bat README.md requirements.txt
+rm -rf .github content repl .gitignore .jupyterlite.doit.db deploy-ghp.sh README.md requirements.txt
 
 REM only files/dir from ./dist will be commited
 cp -r ./dist/* ./

--- a/deploy-ghp.sh
+++ b/deploy-ghp.sh
@@ -19,10 +19,10 @@ git clean -f
 git rm --cached deploy-ghp.sh
 git commit -m "Remove deploy script"
 
-# put all repo files/dif in .gitignore
-ls -aI .gitignore -I . -I .. > .gitignore
+# remove all but deploy script
+rm -rf .github content repl .gitignore .jupyterlite.doit.db deploy-ghp.bat README.md requirements.txt
 
-# only files/dir from ./docs/.vitepress/dist will be commited
+# only files/dir from ./dist will be commited
 cp -r ./dist/* ./
 
 git add .

--- a/deploy-ghp.sh
+++ b/deploy-ghp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# make sure git is clear:
+# git status --porcelain
+
+git push origin --delete gh-pages
+git branch -D gh-pages
+
+git checkout --orphan gh-pages
+
+git rm --cached -rf .
+
+git add deploy-ghp.sh
+git commit -m "Add deploy script"
+
+# git clean -n
+git clean -f
+
+git rm --cached deploy-ghp.sh
+git commit -m "Remove deploy script"
+
+# put all repo files/dif in .gitignore
+ls -aI .gitignore -I . -I .. > .gitignore
+
+# only files/dir from ./docs/.vitepress/dist will be commited
+cp -r ./dist/* ./
+
+git add .
+git commit -m "Deploy"
+git push --set-upstream origin gh-pages
+
+git checkout main


### PR DESCRIPTION
As a user, I would rather not jump directly to full automation - with GA.  
Instead, I am much more interested to go step by step, and only when full understood, use magical automation.   

Somebody who wants to create a custom jupytelite may start from there and iterate/change the repo to fine tune their specifics.  
Then the deploy script is so fast that in many cases it is a good option to just run it - like you would run say a "git push --tags".

Hope this helps.