### PR TITLE
Update to JupyterLite 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Core modules (mandatory)
-jupyterlite-core==0.1.1
-jupyterlab~=3.5.1
+jupyterlite-core==0.2.0a0
+jupyterlab~=4.0.5
 
 # Python kernel (optional)
 jupyterlite-pyodide-kernel==0.0.10
 
 # JavaScript kernel (optional)
-jupyterlite-javascript-kernel==0.1.1
+jupyterlite-javascript-kernel==0.2.0a0
 
 # Language support (optional)
 jupyterlab-language-pack-fr-FR
@@ -20,9 +20,9 @@ jupyterlite-p5-kernel==0.1.0
 jupyterlite-xeus-lua==0.3.1
 
 # JupyterLab: Fasta file renderer (optional)
-jupyterlab-fasta>=3,<4
+jupyterlab-fasta>=4,<5
 # JupyterLab: Geojson file renderer (optional)
-jupyterlab-geojson>=3,<4
+jupyterlab-geojson>=4,<5
 # JupyterLab: guided tour (optional)
 jupyterlab-tour
 # JupyterLab: dark theme


### PR DESCRIPTION
As discussed in https://github.com/jupyterlite/demo/issues/125

Update to the latest `0.2.0` pre-releases.

This PR will stay in draft until the beta / rc.