### PR TITLE
Rolled back ipywidgets to ==8.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ jupyterlab-night
 jupyterlab_miami_nights
 
 # Python: ipywidget library for Jupyter notebooks (optional)
-ipywidgets>=8.1.1,<9
+ipywidgets==8.1.1
 # Python: ipyevents library for Jupyter notebooks (optional)
 ipyevents>=2.0.1
 # Python: interative Matplotlib library for Jupyter notebooks (optional)


### PR DESCRIPTION
This pull request rolls back the version of ipywidgets to ==8.1.1 as 8.1.2 broke the widget examples when I tested them.

On my cloned version of the demo repo, this change to requirements.txt fixed the issue.

Thanks for your hard work on this terrific project!