### PR TITLE
docs: add a reference to the Xeus kernel template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ For more info, keep an eye on the JupyterLite documentation:
 
 - How-to Guides: https://jupyterlite.readthedocs.io/en/latest/howto/index.html
 - Reference: https://jupyterlite.readthedocs.io/en/latest/reference/index.html
+
+This theme provides the Pyodide kernel (`jupyterlite-pyodide-kernel`), the JavaScript kernel (`jupyterlite-javascript-kernel`), and the p5 kernel (`jupyterlite-p5-kernel`), along with other
+optional utilities and extensions to make the JupyterLite experience more enjoyable. See the
+[`requirements.txt` file](requirements.txt) for a list of all the dependencies provided.
+
+For a template based on the Xeus kernel, see the [`jupyterlite/xeus-python-demo` repository](https://github.com/jupyterlite/xeus-python-demo)
+
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more info, keep an eye on the JupyterLite documentation:
 - How-to Guides: https://jupyterlite.readthedocs.io/en/latest/howto/index.html
 - Reference: https://jupyterlite.readthedocs.io/en/latest/reference/index.html
 
-This theme provides the Pyodide kernel (`jupyterlite-pyodide-kernel`), the JavaScript kernel (`jupyterlite-javascript-kernel`), and the p5 kernel (`jupyterlite-p5-kernel`), along with other
+This template provides the Pyodide kernel (`jupyterlite-pyodide-kernel`), the JavaScript kernel (`jupyterlite-javascript-kernel`), and the p5 kernel (`jupyterlite-p5-kernel`), along with other
 optional utilities and extensions to make the JupyterLite experience more enjoyable. See the
 [`requirements.txt` file](requirements.txt) for a list of all the dependencies provided.
 


### PR DESCRIPTION
## Description

It was tricky for a user to see how to set up a Xeus/`xeus-python`-based deployment from this repository, and I think that this repository can link to the https://github.com/jupyterlite/xeus-python-demo for that. Since the README there also contains a short comparison of the Pyodide and Xeus kernels, I think adding this cross-reference would help newcomers who would like to switch between kernels, as this repository shows up as the second search result for "jupyterlite template" on search engines and one needs to search for "jupyterlite template xeus" explicitly to find the Xeus one.

## Changes added

- Mentioned which kernels are available through this template
- Cross-linked to the Xeus template repository

P.S. Maybe this has already been discussed elsewhere, but a `cookiecutter` template (or better, one using `copier`) that would unify both repositories would also be nice. However, that would not work with the green "Use this template" button on GitHub, which is quicker.