### PR TITLE
Bring back `jupyterlab-tour` as an optional requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,7 @@ jupyterlab-fasta>=3.3.0,<4
 # JupyterLab: Geojson file renderer (optional)
 jupyterlab-geojson>=3.4.0,<4
 # JupyterLab: guided tour (optional)
-# TODO: re-enable after https://github.com/jupyterlab-contrib/jupyterlab-tour/issues/82
-# jupyterlab-tour
+jupyterlab-tour
 # JupyterLab: dark theme
 jupyterlab-night
 # JupyterLab: Miami nights theme (optional)


### PR DESCRIPTION
## Description

This is a small PR that adds `jupyterlab-tour` as an optional requirement in `requirements.txt`, as https://github.com/jupyterlab-contrib/jupyterlab-tour/issues/82 has now been resolved.