### PR TITLE
Revert "Bring back `jupyterlab-tour` as an optional requirement"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ jupyterlab-fasta>=3.3.0,<4
 # JupyterLab: Geojson file renderer (optional)
 jupyterlab-geojson>=3.4.0,<4
 # JupyterLab: guided tour (optional)
-jupyterlab-tour
+# TODO: re-enable after https://github.com/jupyterlab-contrib/jupyterlab-tour/issues/82
+# jupyterlab-tour
 # JupyterLab: dark theme
 jupyterlab-night
 # JupyterLab: Miami nights theme (optional)


### PR DESCRIPTION
Reverts jupyterlite/demo#153

See https://github.com/jupyterlite/demo/pull/153#issuecomment-2940860252